### PR TITLE
PIC-145: Создать query параметры для страничек чата и настроек

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -38,10 +38,14 @@ jobs:
     - name: Linter check
       run: npm run eslint-check
     - name: Deploy app
-      uses: akhileshns/heroku-deploy@master
+      uses: appleboy/ssh-action@master
       with:
-        heroku_api_key: ${{secrets.HEROKU_API_KEY}}
-        heroku_app_name: lepick
-        heroku_email: wh75er@gmail.com
-      
-      
+        host: ${{ secrets.HOST }}
+        username: ${{ secrets.USERNAME }}
+        key: ${{ secrets.SSH_KEY }}
+        script: |
+          cd ${{ secrets.PROJECT_DIR }} && git pull -f
+          cd ${{ secrets.PROJECT_DIR }} && npm i && npm build
+          sudo rm ${{ secrets.NGINX_DIR }}/*
+          sudo cp ${{ secrets.PROJECT_DIR }}/dist/* ${{ secrets.NGINX_DIR }}/*
+

--- a/src/components/ChatItem/ChatItem.scss
+++ b/src/components/ChatItem/ChatItem.scss
@@ -7,7 +7,10 @@
     overflow: hidden;
 }
 
-.chat-item__time::before {
+.chat-item__time {
+}
+
+.chat-item__time_separator::before {
     margin-right: 10px;
     margin-bottom: 3px;
     display: inline-block;

--- a/src/components/ChatItem/ChatItem.ts
+++ b/src/components/ChatItem/ChatItem.ts
@@ -35,12 +35,12 @@ class ChatItem extends Component {
             }
         }
 
-        if (this.context.lastMessage && this.context.lastMessage.text) {
-            this.context.caption = `<div class="chat-item__last-message">${this.context.lastMessage.text}</div>`;
-            if (this.context.lastMessage.time) {
-                this.context.caption += `<div class="chat-item__time">${this.context.lastMessage.time}</div>`;
-            }
-        }
+        const lastMessageText = this.context.lastMessage.text ? this.context.lastMessage.text : '';
+        const lastMessageTime = this.context.lastMessage.time ? this.context.lastMessage.time : '';
+        this.context.caption = `<div class="chat-item__last-message">${lastMessageText}</div>`;
+
+        const chatTimeClasses = lastMessageTime ? 'chat-item__time chat-item__time_separator' : 'chat-item__time';
+        this.context.caption += `<div class="${chatTimeClasses}">${lastMessageTime}</div>`;
     }
 
     /**

--- a/src/consts/config.ts
+++ b/src/consts/config.ts
@@ -1,6 +1,7 @@
-const url = 'p1ckle.herokuapp.com';
-const backendLocation = 'https://' + url;
-export const websocketLocation = 'wss://' + url + '/ws';
+const url = 'lepick.ru';
+const backendLocation = 'https://' + url + '/backend';
+export const websocketLocation = 'wss://' + url + '/backend/ws';
+export const imageBackendLocation = 'https://' + url + '/images';
 export const imageStorageLocation = 'https://lepick-images.s3.eu-central-1.amazonaws.com';
 
 export default backendLocation;

--- a/src/consts/events.ts
+++ b/src/consts/events.ts
@@ -4,7 +4,8 @@ const Events = {
     updateAvatar: 'updateAvatar',
     newMessage: 'newMessage',
     newChat: 'newChat',
-    messageChanged: 'messageChanged'
+    messageChanged: 'messageChanged',
+    queryChange: 'queryChange'
 };
 
 export default Events;

--- a/src/controllers/MessageController.ts
+++ b/src/controllers/MessageController.ts
@@ -319,6 +319,7 @@ class MessageController extends BaseController {
             }
 
             if (lastTime && chat.lastMessage.time) {
+                lastTime.classList.add('chat-item__time_separator');
                 lastTime.innerHTML = chat.lastMessage.time;
             }
         }

--- a/src/models/ChatModel.ts
+++ b/src/models/ChatModel.ts
@@ -186,7 +186,8 @@ class ChatModel {
                 ok: true,
                 json: this.chats.map((chat: Context) => ({
                     ...chat,
-                    lastMessageTime: timeToStringByTime(new Date(chat.lastMessageTime))
+                    lastMessageTime: timeToStringByTime(new Date(chat.lastMessageTime)),
+                    photo: imageStorageLocation + '/' + chat.photo
                 }))
             });
         }
@@ -206,14 +207,15 @@ class ChatModel {
                             partnerId: chat.partnerId,
                             partnerName: chat.partnerName,
                             lastMessage: chat.lastMessage,
-                            lastMessageTime: chat.lastMessageTime * 1000,
-                            photo: imageStorageLocation + '/' + chat.photos[0]
+                            lastMessageTime: chat.lastMessageTime ? chat.lastMessageTime * 1000 : undefined,
+                            photo: chat.photos[0]
                         };
                     });
                     response.json = this.chats.map((chat: Context) => {
                         return {
                             ...chat,
-                            lastMessageTime: timeToStringByTime(new Date(chat.lastMessageTime))
+                            lastMessageTime: timeToStringByTime(new Date(chat.lastMessageTime)),
+                            photo: imageStorageLocation + '/' + chat.photo
                         };
                     });
                 }

--- a/src/models/UserModel.ts
+++ b/src/models/UserModel.ts
@@ -1,7 +1,7 @@
 import HttpRequests from '../utils/requests';
 import { addIfNotEq, filterObject, parseJson, IResponseData, isActive } from '../utils/helpers';
 import Context from '../utils/Context';
-import { imageStorageLocation } from '../consts/config';
+import { imageStorageLocation, imageBackendLocation } from '../consts/config';
 
 export interface IUserModel {
     error?: Context;
@@ -310,7 +310,10 @@ class UserModel {
      * @return {Promise}
      */
     uploadPhoto(photo: File) {
-        return HttpRequests.postBinary('/images', photo)
+        const options = {
+            url: imageBackendLocation
+        };
+        return HttpRequests.postBinary('/images', photo, options)
             .then(parseJson)
             .then((response) => {
                 if (response.ok) {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -130,6 +130,9 @@ export function handleReactionPromise(response: Response): Context {
 
     const newChatData = response.json as IChatItem;
     if (newChatData?.chatId) {
+        eventBus.emit(Events.pushNotifications, {
+            children: 'У вас новая пара!'
+        });
         eventBus.emit(Events.newChat, newChatData);
     }
 
@@ -146,6 +149,9 @@ export function handleReactionPromise(response: Response): Context {
 }
 
 export function timeToStringByTime(date: Date): string {
+    if (isNaN(date.getDate())) {
+        return '';
+    }
     if (typeof date === 'string') date = new Date(date);
     const timeDiff = (Number(new Date()) - Number(date)) / 1000;
 
@@ -217,7 +223,7 @@ interface IChatPatch {
 }
 
 export function updateChat(chats: IChat[], chatPatch: IChatPatch): void {
-    for (let chat of chats) {
+    chats.forEach(function patchChat(chat: IChat, index: number) {
         if (chat.chatId === chatPatch.chatId) {
             for (const key of Object.keys(chat)) {
                 const tmpKey = key as keyof IChatPatch;
@@ -225,9 +231,9 @@ export function updateChat(chats: IChat[], chatPatch: IChatPatch): void {
                     chat = { ...chat, [tmpKey]: chatPatch[tmpKey] };
                 }
             }
-            break;
         }
-    }
+        this[index] = chat;
+    }, chats);
 }
 
 export const badInternet = (): void => {

--- a/src/utils/requests.ts
+++ b/src/utils/requests.ts
@@ -11,11 +11,23 @@ class BaseRequest {
      *
      * @param {string} method указание метода HTTP запроса
      * @param {string} route указание пути принимающей стороне
-     * @param {any} body тело запроса
-     * @param {boolean} binary является ли запрос бинарным
+     * @param {Context} body тело запроса
+     * @param {Context} reqOptions опции для запроса
      * @return {Promise}
      */
-    request(method = 'GET', route = '/', body: Context = null, binary?: boolean): Promise<Response> {
+    request(method = 'GET', route = '/', body: Context = null, reqOptions: Context = {}): Promise<Response> {
+        let binary = false;
+        let url = backendLocation;
+
+        if (reqOptions) {
+            if (reqOptions.binary === true) {
+                binary = true;
+            }
+            if (reqOptions.url) {
+                url = reqOptions.url;
+            }
+        }
+
         const options: RequestInit = {
             method: method,
             mode: 'cors',
@@ -37,7 +49,7 @@ class BaseRequest {
             options.body = body;
         }
 
-        return fetch(backendLocation + route, options).then((response) => {
+        return fetch(url + route, options).then((response) => {
             if (response.headers.get('X-CSRF-Token')) {
                 window.localStorage.setItem('CSRFToken', response.headers.get('X-CSRF-Token'));
             }
@@ -45,8 +57,8 @@ class BaseRequest {
         });
     }
 
-    makeRequest(route = 'POST', body: Context = null, binary?: boolean): Promise<Response> {
-        return this.request(route, route, body, binary);
+    makeRequest(route = '/', body: Context = null, options: Context = {}): Promise<Response> {
+        return this.request('POST', route, body, options);
     }
 }
 
@@ -60,10 +72,11 @@ class PostRequest extends BaseRequest {
      *
      * @param {string} route указание пути принимающей стороне
      * @param {Object} body тело запроса
+     * @param {object} options опции запроса
      * @return {Promise}
      */
-    makeRequest(route: string, body: Context): Promise<Response> {
-        return this.request('POST', route, body);
+    makeRequest(route: string, body: Context, options: Context = {}): Promise<Response> {
+        return this.request('POST', route, body, options);
     }
 }
 
@@ -77,10 +90,12 @@ class GetRequest extends BaseRequest {
      *
      * @param {string} route указание пути принимающей стороне
      * @param {Object} body пустой объект
+     * @param {object} options опции запроса
      * @return {Promise}
      */
-    makeRequest(route: string): Promise<Response> {
-        return this.request('GET', route);
+    makeRequest(route: string, body: Context = null, options: Context = {}): Promise<Response> {
+        body = null;
+        return this.request('GET', route, body, options);
     }
 }
 
@@ -94,10 +109,11 @@ class PutRequest extends BaseRequest {
      *
      * @param {string} route указание пути принимающей стороне
      * @param {Object} body тело запроса
+     * @param {object} options опции запроса
      * @return {Promise}
      */
-    makeRequest(route: string, body: Context): Promise<Response> {
-        return this.request('PUT', route, body);
+    makeRequest(route: string, body: Context, options: Context = {}): Promise<Response> {
+        return this.request('PUT', route, body, options);
     }
 }
 
@@ -111,10 +127,11 @@ class PatchRequest extends BaseRequest {
      *
      * @param {string} route указание пути принимающей стороне
      * @param {Object} body тело запроса
+     * @param {object} options опции запроса
      * @return {Promise}
      */
-    makeRequest(route: string, body: Context): Promise<Response> {
-        return this.request('PATCH', route, body);
+    makeRequest(route: string, body: Context, options: Context = {}): Promise<Response> {
+        return this.request('PATCH', route, body, options);
     }
 }
 
@@ -128,10 +145,11 @@ class DeleteRequest extends BaseRequest {
      *
      * @param {string} route указание пути принимающей стороне
      * @param {Object} body тело запроса
+     * @param {object} options опции запроса
      * @return {Promise}
      */
-    makeRequest(route: string, body: Context): Promise<Response> {
-        return this.request('DELETE', route, body);
+    makeRequest(route: string, body: Context, options: Context = {}): Promise<Response> {
+        return this.request('DELETE', route, body, options);
     }
 }
 
@@ -145,10 +163,11 @@ class BinaryPostRequest extends BaseRequest {
      *
      * @param {string} route указание пути принимающей стороне
      * @param {Object} body тело запроса
+     * @param {object} options опции запроса
      * @return {Promise}
      */
-    makeRequest(route: string, body: Context): Promise<Response> {
-        return this.request('POST', route, body, true);
+    makeRequest(route: string, body: Context, options: Context = {}): Promise<Response> {
+        return this.request('POST', route, body, { ...options, binary: true });
     }
 }
 
@@ -188,10 +207,11 @@ class HttpRequests {
      * Alias для makeRequest для GET запроса
      *
      * @param {string} route указание пути на принимающей стороне
+     * @param {object} options опции запроса
      * @return {Promise} Ответ на запрос
      */
-    get(route: string): Promise<Response> {
-        return this.makeRequest('get', route);
+    get(route: string, options: Context = {}): Promise<Response> {
+        return this.makeRequest('get', route, null, options);
     }
 
     /**
@@ -199,10 +219,11 @@ class HttpRequests {
      *
      * @param {string} route указание пути на принимающей стороне
      * @param {object} body указание пути принимающей стороне
+     * @param {object} options опции запроса
      * @return {Promise} Ответ на запрос
      */
-    post(route: string, body: Context): Promise<Response> {
-        return this.makeRequest('post', route, body);
+    post(route: string, body: Context, options: Context = {}): Promise<Response> {
+        return this.makeRequest('post', route, body, options);
     }
 
     /**
@@ -210,10 +231,11 @@ class HttpRequests {
      *
      * @param {string} route указание пути на принимающей стороне
      * @param {object} body указание пути принимающей стороне
+     * @param {object} options опции запроса
      * @return {Promise} Ответ на запрос
      */
-    put(route: string, body: Context): Promise<Response> {
-        return this.makeRequest('put', route, body);
+    put(route: string, body: Context, options: Context = {}): Promise<Response> {
+        return this.makeRequest('put', route, body, options);
     }
 
     /**
@@ -221,10 +243,11 @@ class HttpRequests {
      *
      * @param {string} route указание пути на принимающей стороне
      * @param {object} body указание пути принимающей стороне
+     * @param {object} options опции запроса
      * @return {Promise} Ответ на запрос
      */
-    patch(route: string, body: Context): Promise<Response> {
-        return this.makeRequest('patch', route, body);
+    patch(route: string, body: Context, options: Context = {}): Promise<Response> {
+        return this.makeRequest('patch', route, body, options);
     }
 
     /**
@@ -232,14 +255,15 @@ class HttpRequests {
      *
      * @param {string} route указание пути на принимающей стороне
      * @param {object} body указание пути принимающей стороне
+     * @param {object} options опции запроса
      * @return {Promise} Ответ на запрос
      */
-    delete(route: string, body: Context): Promise<Response> {
-        return this.makeRequest('delete', route, body);
+    delete(route: string, body: Context, options: Context = {}): Promise<Response> {
+        return this.makeRequest('delete', route, body, options);
     }
 
-    postBinary(route: string, body: Context): Promise<Response> {
-        return this.makeRequest('binary', route, body);
+    postBinary(route: string, body: Context, options: Context = {}): Promise<Response> {
+        return this.makeRequest('binary', route, body, options);
     }
 
     /**
@@ -248,9 +272,10 @@ class HttpRequests {
      * @param {string} method указание HTTP метода для передачи данных
      * @param {string} route указание пути на принимающей стороне
      * @param {object} body указание пути принимающей стороне
+     * @param {object} options указание опций запроса
      * @return {Promise} Ответ на запрос
      */
-    makeRequest(method: string, route: string, body: Context = null): Promise<Response> {
+    makeRequest(method: string, route: string, body: Context = null, options: Context = {}): Promise<Response> {
         if (!(method in this.requests)) {
             return Promise.reject(new Error(`Request method ${method} does not exist`));
         }
@@ -258,7 +283,7 @@ class HttpRequests {
         for (const [kMethod, handler] of Object.entries(this.requests)) {
             const req = <BaseRequest>handler;
             if (kMethod === method) {
-                return req.makeRequest(route, body);
+                return req.makeRequest(route, body, options);
             }
         }
     }


### PR DESCRIPTION
Изменения:

-  На страничке настроек теперь доступен query параметр page={идентификатор вкладки настройки: main,photo,photoSecret, password}. Можно переходить на нужную вкладку через url.
- На страничке с чатами добавлен query параметр chatId={номер чата}. Между чатами теперь можно перемещаться через url, выбирая правильный номер чата.
- Для выше перечисленных страничек query параметр меняется в зависимости от выбранного чата или выбранных опций, состояние заностися в историю, поэтому по ним можно перемещаться с помощью стрелок в браузере
- Фикс багов у чата - теперь чат работает нормально:
    - Оповещения о матче приходят теперь обоим людям, а не только тому, кто лайкнул первым.
    - Превью сообщения в чатах теперь рабоатет корректно. В пустом чате оно сразу появляется и изменяется при входящих и исходящих сообщениях.
    - При добавлении чата(при матче) исправлен баг с битой аватаркой
- Изменение логики работы fetch API. Добавлена возможность прокидивать опции, в которых можно указать url принимающей стороны.
- Изменение логики отправки запроса на добавление картинок. Теперь они отправляются на другой url